### PR TITLE
Update docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
   root: true,
-  extends: ['eslint-config-digitalbazaar'],
+  extends: [
+    'eslint-config-digitalbazaar',
+    'eslint-config-digitalbazaar/jsdoc'
+  ],
   env: {
     node: true
   },
@@ -8,6 +11,7 @@ module.exports = {
     CryptoKey: true,
     TextDecoder: true,
     TextEncoder: true,
-    Uint8Array: true
+    Uint8Array: true,
+    window: true
   }
 }

--- a/AsymmetricKey.js
+++ b/AsymmetricKey.js
@@ -10,16 +10,16 @@ export class AsymmetricKey {
   /**
    * Creates a new instance of an asymmetric key.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The public key ID to use when expressing
    *   this key publicly (i.e., as a verification method); this may be
    *   different from the key ID used to identify the key with the KMS, which
    *   case pass `kmsId` as well.
    * @param {string} [options.kmsId=options.id] - The private key ID used to
    *   identify the key with the KMS.
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of KmsClient methods.
-   * @param {Object} options.invocationSigner - An API for signing
+   * @param {object} options.invocationSigner - An API for signing
    *   a capability invocation.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
@@ -43,7 +43,7 @@ export class AsymmetricKey {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {Uint8Array} options.data - The data to sign as a Uint8Array.
    *
    * @returns {Promise<Uint8Array>} The signature.
@@ -61,7 +61,7 @@ export class AsymmetricKey {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {Uint8Array} options.data - The data to sign as a Uint8Array.
    * @param {string} options.signature - The base64url-encoded signature to
    *   verify.

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -19,14 +19,14 @@ const _seedCache = new SeedCache();
 
 export class ControllerKey {
   /**
-   * Creates a new instance of a ControllerKey. This function should never
-   * be called directly. Use one of these methods to create a ControllerKey
-   * instance.
-   *
+   * Creates a new instance of a ControllerKey.
    * A ControllerKey can be passed as an `invocationSigner` to a KmsClient, but
    * a KmsClient instance is typically used internally by other instances that
    * can be created via the ControllerKey API such as instances of the Kek
    * and Hmac classes.
+   *
+   * This function should never be called directly.
+   * Use one of these methods to create a ControllerKey instance.
    *
    * @example
    * ControllerKey.fromSecret();
@@ -116,9 +116,10 @@ export class ControllerKey {
    * wrap or unwrap keys.
    *
    * If this ControllerKey is a controller of the KEK, then the API for it can
-   * returned by passing only the key description. Otherwise, an OCAP-LD
-   * authorization capability must also be passed; without this capability,
-   * calls to the returned API will not be authorized to perform KEK operations.
+   * be returned by passing only the key description (the id and type).
+   * Otherwise, an OCAP-LD authorization capability must also be passed;
+   * without this capability, calls to the returned API will not be authorized
+   * to perform KEK operations.
    *
    * @param {Object} options - The options to use.
    * @param {string} options.id - The ID of the key.
@@ -141,7 +142,7 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the HMAC, then the API for it can
-   * returned by passing only the key description. Otherwise, an OCAP-LD
+   * be returned by passing only the key description. Otherwise, an OCAP-LD
    * authorization capability must also be passed; without this capability,
    * calls to the returned API will not be authorized to perform HMAC
    * operations.
@@ -166,12 +167,12 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the AsymmetricKey, then the API
-   * for it can returned by passing only the key description. Otherwise, an
+   * for it can be returned by passing only the key type. Otherwise, an
    * authorization capability must also be passed; without this capability,
    * calls to the returned API will not be authorized to perform asymmetric key
    * operations.
    *
-   * @param {Object} options - The options to use.
+   * @param {Object} options - The options for generating an Asymmetric Key.
    * @param {string} options.id - The public ID of the key; if the public ID
    *   is different from the private KMS ID, pass it separately as `kmsId`.
    * @param {string} [options.kmsId=options.id] - The private ID of this key
@@ -196,7 +197,7 @@ export class ControllerKey {
    * shared secrets.
    *
    * If this ControllerKey is a controller of the KeyAgreementKey, then the API
-   * for it can returned by passing only the key description. Otherwise, an
+   * for it can be returned by passing only the key description. Otherwise, an
    * authorization capability must also be passed; without this capability,
    * calls to the returned API will not be authorized to perform key agreement
    * key operations.

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -26,10 +26,9 @@ export class ControllerKey {
    * can be created via the ControllerKey API such as instances of the Kek
    * and Hmac classes.
    *
-   * The ControllerKey should never be called directly.
-   * It should always be created via a static method on the class.
-   * Use one of the static methods in examples to create
-   * a ControllerKey instance.
+   * The ControllerKey should never be called directly. It should always be
+   * created via a static method on the class. Use one of the static methods
+   * in the examples to create a ControllerKey instance.
    *
    * @example
    * ControllerKey.fromSecret();

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -118,10 +118,9 @@ export class ControllerKey {
    * wrap or unwrap keys.
    *
    * If this ControllerKey is a controller of the KEK, then the API for it can
-   * be returned by passing only the key id and type. Otherwise,
-   * an OCAP-LD authorization capability must also be passed;
-   * without this capability, calls to the returned API will not be authorized
-   * to perform KEK operations.
+   * be returned by passing only the key id and type. Otherwise, an OCAP-LD
+   * authorization capability must also be passed; without this capability,
+   * calls to the returned API will not be authorized to perform KEK operations.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The ID of the key.
@@ -144,10 +143,10 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the HMAC, then the API for it can
-   * be returned by passing only the key id and type. Otherwise,
-   * an OCAP-LD authorization capability must also be passed;
-   * without this capability, calls to the returned API will not
-   * be authorized to perform HMAC operations.
+   * be returned by passing only the key id and type. Otherwise, an OCAP-LD
+   * authorization capability must also be passed; without this capability,
+   * calls to the returned API will not be authorized to perform HMAC
+   * operations.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The ID of the key.

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -34,15 +34,15 @@ export class ControllerKey {
    * ControllerKey.fromBiometric();
    * ControllerKey.fromFido();
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.handle - The semantic identifier that was used to
    *   create the key.
-   * @param {Object} options.signer - An API with an `id` property, a
+   * @param {object} options.signer - An API with an `id` property, a
    *   `type` property, and a `sign` function for authentication purposes.
-   * @param {Object} options.keyPair - The underlying key pair.
+   * @param {object} options.keyPair - The underlying key pair.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
-   * @returns {ControllerKey} the new instance.
+   * @returns {ControllerKey} The new instance.
    */
   constructor({handle, signer, keyPair, kmsClient = new KmsClient()}) {
     this.handle = handle;
@@ -56,10 +56,10 @@ export class ControllerKey {
   /**
    * Digitally signs the given data.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {Uint8Array} options.data - The data to sign.
    *
-   * @returns {Promise<Uint8Array>} resolves to the signature.
+   * @returns {Promise<Uint8Array>} Resolves to the signature.
    */
   async sign({data}) {
     return this._signer.sign({data});
@@ -70,7 +70,7 @@ export class ControllerKey {
    * key. It can be generated using a FIPS-compliant algorithm or the latest
    * recommended algorithm.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.type - The type of key to create (`hmac` or `kek`).
    * @param {string} options.kmsModule - The name of the KMS module to use to
    *   generate the key.
@@ -78,7 +78,7 @@ export class ControllerKey {
    *   use FIPS-compliant ciphers, `recommended` to use the latest recommended
    *   ciphers.
    *
-   * @returns {Promise<Object>} A Kek or Hmac instance.
+   * @returns {Promise<object>} A Kek or Hmac instance.
    */
   async generateKey({type, kmsModule, version = 'recommended'}) {
     _assertVersion(version);
@@ -121,14 +121,14 @@ export class ControllerKey {
    * without this capability, calls to the returned API will not be authorized
    * to perform KEK operations.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The ID of the key.
    * @param {string} options.type - The type of key
    *   (e.g. `AesKeyWrappingKey2019`).
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of the operations.
    *
-   * @returns {Promise<Object>} The new Kek instance.
+   * @returns {Promise<object>} The new Kek instance.
    */
   async getKek({id, type, capability}) {
     const {kmsClient} = this;
@@ -142,18 +142,19 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the HMAC, then the API for it can
-   * be returned by passing only the key description. Otherwise, an OCAP-LD
-   * authorization capability must also be passed; without this capability,
+   * be returned by passing only the key description (the id and type).
+   * Otherwise, an OCAP-LD authorization capability must also be passed;
+   * without this capability,
    * calls to the returned API will not be authorized to perform HMAC
    * operations.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The ID of the key.
    * @param {string} options.type - The type of key (e.g. `Sha256HmacKey2019`).
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of the operations.
    *
-   * @returns {Promise<Object>} The new Hmac instance.
+   * @returns {Promise<object>} The new Hmac instance.
    */
   async getHmac({id, type, capability}) {
     const {kmsClient} = this;
@@ -167,22 +168,22 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the AsymmetricKey, then the API
-   * for it can be returned by passing only the key type. Otherwise, an
-   * authorization capability must also be passed; without this capability,
-   * calls to the returned API will not be authorized to perform asymmetric key
-   * operations.
+   * for it can be returned by passing only the id and type.
+   * Otherwise, an authorization capability must also be passed;
+   * without this capability, calls to the returned API will not be
+   * authorized to perform asymmetric key operations.
    *
-   * @param {Object} options - The options for generating an Asymmetric Key.
+   * @param {object} options - The options for generating an Asymmetric Key.
    * @param {string} options.id - The public ID of the key; if the public ID
    *   is different from the private KMS ID, pass it separately as `kmsId`.
    * @param {string} [options.kmsId=options.id] - The private ID of this key
    *   with the KMS.
    * @param {string} options.type - The type of key
    *   (e.g. `Ed25519VerificationKey2018`).
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of the operations.
    *
-   * @returns {Promise<Object>} The new Hmac instance.
+   * @returns {Promise<object>} The new Hmac instance.
    */
   async getAsymmetricKey({id, kmsId, type, capability}) {
     const {kmsClient} = this;
@@ -197,22 +198,22 @@ export class ControllerKey {
    * shared secrets.
    *
    * If this ControllerKey is a controller of the KeyAgreementKey, then the API
-   * for it can be returned by passing only the key description. Otherwise, an
-   * authorization capability must also be passed; without this capability,
-   * calls to the returned API will not be authorized to perform key agreement
-   * key operations.
+   * for it can be returned by passing only the id and type.
+   * Otherwise, an authorization capability must also be passed;
+   * without this capability, calls to the returned API will not be
+   * authorized to perform key agreement key operations.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The public ID of the key; if the public ID
    *   is different from the private KMS ID, pass it separately as `kmsId`.
    * @param {string} [options.kmsId=options.id] - The private ID of this key
    *   with the KMS.
    * @param {string} options.type - The type of key
    *   (e.g. `X25519KeyAgreementKey2019`).
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of the operations.
    *
-   * @returns {Promise<Object>} The new Hmac instance.
+   * @returns {Promise<object>} The new Hmac instance.
    */
   async getKeyAgreementKey({id, kmsId, type, capability}) {
     const {kmsClient} = this;
@@ -226,14 +227,14 @@ export class ControllerKey {
    * uniquely identify the secret, and a key name. The same secret can be
    * used to generate multiple keys by using different key names.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string|Uint8Array} [options.secret] - A secret to use as input
    *   when generating the key, e.g., a bcrypt hash of a password.
    * @param {string} options.handle - A semantic identifier for the secret
    *   that is mixed with it like a salt to produce a seed, and, if `cache` is
    *   true, will be used to identify the seed in the cache. A common use for
    *   this field is to use the account ID for a user in a system.
-   * @param {keyName} [options.keyName='root'] - An optional name to use to
+   * @param {string} [options.keyName='root'] - An optional name to use to
    *   generate the key.
    * @param {boolean} [options.cache=true] - Use `true` to cache the seed for
    *   the key, `false` not to; a cached seed must be cleared via `clearCache`
@@ -280,10 +281,10 @@ export class ControllerKey {
    * the key for the given account has been previously cached. To clear this
    * key to prevent future loading, call `clearCache` with the key's `handle`.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.handle - The semantic identifier that was used to
    *   create the seed and differentiate it in the cache.
-   * @param {keyName} [options.keyName='default'] - An optional name to use to
+   * @param {string} [options.keyName='default'] - An optional name to use to
    *   generate the key.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
@@ -308,7 +309,7 @@ export class ControllerKey {
    * via `fromSecret` with `cache` set to `true` in order to ensure the key
    * cannot be loaded via `fromCache`.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options for the caches.
    * @param {string} options.handle - The semantic identifier that was used to
    *   create the key and differentiate it in the cache.
    *

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -20,13 +20,16 @@ const _seedCache = new SeedCache();
 export class ControllerKey {
   /**
    * Creates a new instance of a ControllerKey.
+   *
    * A ControllerKey can be passed as an `invocationSigner` to a KmsClient, but
    * a KmsClient instance is typically used internally by other instances that
    * can be created via the ControllerKey API such as instances of the Kek
    * and Hmac classes.
    *
-   * This function should never be called directly.
-   * Use one of these methods to create a ControllerKey instance.
+   * The ControllerKey should never be called directly.
+   * It should always be created via a static method on the class.
+   * Use one of the static methods in examples to create
+   * a ControllerKey instance.
    *
    * @example
    * ControllerKey.fromSecret();
@@ -116,8 +119,8 @@ export class ControllerKey {
    * wrap or unwrap keys.
    *
    * If this ControllerKey is a controller of the KEK, then the API for it can
-   * be returned by passing only the key id and type.
-   * Otherwise, an OCAP-LD authorization capability must also be passed;
+   * be returned by passing only the key id and type. Otherwise,
+   * an OCAP-LD authorization capability must also be passed;
    * without this capability, calls to the returned API will not be authorized
    * to perform KEK operations.
    *
@@ -142,11 +145,10 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the HMAC, then the API for it can
-   * be returned by passing only the key id and type.
-   * Otherwise, an OCAP-LD authorization capability must also be passed;
-   * without this capability,
-   * calls to the returned API will not be authorized to perform HMAC
-   * operations.
+   * be returned by passing only the key id and type. Otherwise,
+   * an OCAP-LD authorization capability must also be passed;
+   * without this capability, calls to the returned API will not
+   * be authorized to perform HMAC operations.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The ID of the key.
@@ -168,10 +170,10 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the AsymmetricKey, then the API
-   * for it can be returned by passing only the id and type.
-   * Otherwise, an authorization capability must also be passed;
-   * without this capability, calls to the returned API will not be
-   * authorized to perform asymmetric key operations.
+   * for it can be returned by passing only the id and type. Otherwise,
+   * an authorization capability must also be passed; without this capability,
+   * calls to the returned API will not be authorized to perform asymmetric
+   * key operations.
    *
    * @param {object} options - The options for generating an Asymmetric Key.
    * @param {string} options.id - The public ID of the key; if the public ID
@@ -198,10 +200,10 @@ export class ControllerKey {
    * shared secrets.
    *
    * If this ControllerKey is a controller of the KeyAgreementKey, then the API
-   * for it can be returned by passing only the id and type.
-   * Otherwise, an authorization capability must also be passed;
-   * without this capability, calls to the returned API will not be
-   * authorized to perform key agreement key operations.
+   * for it can be returned by passing only the id and type. Otherwise,
+   * an authorization capability must also be passed; without this capability,
+   * calls to the returned API will not be authorized to perform key
+   * agreement key operations.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The public ID of the key; if the public ID

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -116,7 +116,7 @@ export class ControllerKey {
    * wrap or unwrap keys.
    *
    * If this ControllerKey is a controller of the KEK, then the API for it can
-   * be returned by passing only the key description (the id and type).
+   * be returned by passing only the key id and type.
    * Otherwise, an OCAP-LD authorization capability must also be passed;
    * without this capability, calls to the returned API will not be authorized
    * to perform KEK operations.
@@ -142,7 +142,7 @@ export class ControllerKey {
    * sign or verify data.
    *
    * If this ControllerKey is a controller of the HMAC, then the API for it can
-   * be returned by passing only the key description (the id and type).
+   * be returned by passing only the key id and type.
    * Otherwise, an OCAP-LD authorization capability must also be passed;
    * without this capability,
    * calls to the returned API will not be authorized to perform HMAC

--- a/ControllerKey.js
+++ b/ControllerKey.js
@@ -175,7 +175,7 @@ export class ControllerKey {
    * calls to the returned API will not be authorized to perform asymmetric
    * key operations.
    *
-   * @param {object} options - The options for generating an Asymmetric Key.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The public ID of the key; if the public ID
    *   is different from the private KMS ID, pass it separately as `kmsId`.
    * @param {string} [options.kmsId=options.id] - The private ID of this key
@@ -311,7 +311,7 @@ export class ControllerKey {
    * via `fromSecret` with `cache` set to `true` in order to ensure the key
    * cannot be loaded via `fromCache`.
    *
-   * @param {object} options - The options for the caches.
+   * @param {object} options - The options to use.
    * @param {string} options.handle - The semantic identifier that was used to
    *   create the key and differentiate it in the cache.
    *

--- a/Hmac.js
+++ b/Hmac.js
@@ -13,12 +13,12 @@ export class Hmac {
   /**
    * Creates a new instance of an HMAC.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The ID for the hmac key.
    * @param {string} options.type - The type for the hmac.
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of KmsClient methods.
-   * @param {Object} options.invocationSigner - An API for signing
+   * @param {object} options.invocationSigner - An API for signing
    *   a capability invocation.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
@@ -45,7 +45,7 @@ export class Hmac {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {Uint8Array} options.data - The data to sign as a Uint8Array.
    *
    * @returns {Promise<string>} The base64url-encoded signature.
@@ -61,7 +61,7 @@ export class Hmac {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {Uint8Array} options.data - The data to sign as a Uint8Array.
    * @param {string} options.signature - The base64url-encoded signature
    *   to verify.

--- a/Hmac.js
+++ b/Hmac.js
@@ -23,6 +23,7 @@ export class Hmac {
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
    * @returns {Hmac} The new Hmac instance.
+   * @see https://tools.ietf.org/html/rfc2104
    */
   constructor({
     id, type, capability, invocationSigner,

--- a/Kek.js
+++ b/Kek.js
@@ -13,12 +13,12 @@ export class Kek {
   /**
    * Creates a new instance of a key encryption key.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The ID for this key.
    * @param {string} options.type - The type for this key.
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of KmsClient methods.
-   * @param {Object} options.invocationSigner - An API for signing
+   * @param {object} options.invocationSigner - An API for signing
    *   a capability invocation.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
@@ -42,9 +42,9 @@ export class Kek {
   /**
    * Wraps a cryptographic key.
    *
-   * @param {Object} options - The options to use.
-   * @param {Uint8Array} options.unwrappedKey - The key material as a
-   *   Uint8Array.
+   * @param {object} options - The options to use.
+   * @param {Uint8Array} options.unwrappedKey - The key material
+   *   as a Uint8Array.
    *
    * @returns {Promise<string>} The base64url-encoded wrapped key bytes.
    */
@@ -57,7 +57,7 @@ export class Kek {
   /**
    * Unwraps a cryptographic key.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.wrappedKey - The wrapped key material as a
    *   base64url-encoded string.
    *

--- a/Kek.js
+++ b/Kek.js
@@ -12,7 +12,7 @@ const JOSE_ALGORITHM_MAP = {
 export class Kek {
   /**
    * Creates a new instance of a key encryption key.
-   * Used to protect the master encryption key e.g. Controller Key.
+   * Used to protect the content encryption key.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The ID for this key.

--- a/Kek.js
+++ b/Kek.js
@@ -12,6 +12,7 @@ const JOSE_ALGORITHM_MAP = {
 export class Kek {
   /**
    * Creates a new instance of a key encryption key.
+   * Used to protect the master encryption key e.g. Controller Key.
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The ID for this key.

--- a/KeyAgreementKey.js
+++ b/KeyAgreementKey.js
@@ -9,15 +9,15 @@ export class KeyAgreementKey {
   /**
    * Creates a new instance of a key agreement key.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.id - The public key ID to use when expressing
    *   this key publicly; this may be different from the key ID used to
    *   identify the key with the KMS, which case pass `kmsId` as well.
    * @param {string} [options.kmsId=options.id] - The private key ID used to
    *   identify the key with the KMS.
-   * @param {Object} [options.capability=undefined] - The OCAP-LD authorization
+   * @param {object} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of KmsClient methods.
-   * @param {Object} options.invocationSigner - An API for signing
+   * @param {object} options.invocationSigner - An API for signing
    *   a capability invocation.
    * @param {KmsClient} [options.kmsClient] - An optional KmsClient to use.
    *
@@ -41,8 +41,8 @@ export class KeyAgreementKey {
   * a shared key itself, but rather input into a key derivation function (KDF)
   * to produce a shared key.
    *
-   * @param {Object} options - The options to use.
-   * @param {Object} options.publicKey - The public key to compute the shared
+   * @param {object} options - The options to use.
+   * @param {object} options.publicKey - The public key to compute the shared
    *   secret against; the public key type must match this KeyAgreementKey's
    *   type.
    *

--- a/KmsClient.js
+++ b/KmsClient.js
@@ -10,24 +10,17 @@ import {signCapabilityInvocation} from 'http-signature-zcap-invoke';
 const SECURITY_CONTEXT_V2_URL = 'https://w3id.org/security/v2';
 const DEFAULT_HEADERS = {Accept: 'application/ld+json, application/json'};
 
-/**
- * A node https module.
- *
- * @typedef {object} https
- * @see https://nodejs.org/docs/latest-v11.x/api/https.html
- */
-
 export class KmsClient {
   /**
    * Creates a new KmsClient.
    *
    * @param {object} options - The options to use.
    * @param {string} [options.keystore=undefined] - The ID of the keystore
-   * that must be a URL that refers to the keystore's root storage
-   * location; if not given,
+   *   that must be a URL that refers to the keystore's root storage
+   *   location; if not given,
    *   then a separate capability must be given to each method called on the
    *   client instance.
-   * @param {https.Agent} [options.httpsAgent=undefined] - An optional
+   * @param {object} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
    * @returns {KmsClient} The new instance.
@@ -513,7 +506,7 @@ export class KmsClient {
    * @param {object} options - The options to use.
    * @param {string} options.url - The url to post the configuration to.
    * @param {string} options.config - The keystore's configuration.
-   * @param {https.Agent} [options.httpsAgent=undefined] - An optional
+   * @param {object} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
    * @returns {Promise<object>} Resolves to the configuration for the newly
@@ -533,7 +526,7 @@ export class KmsClient {
    *
    * @param {object} options - The options to use.
    * @param {string} options.id - The keystore's ID.
-   * @param {https.Agent} [options.httpsAgent=undefined] - An optional
+   * @param {object} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
    * @returns {Promise<object>} Resolves to the configuration for the keystore.
@@ -552,7 +545,7 @@ export class KmsClient {
    * @param {string} [options.url] - The url to query.
    * @param {string} options.controller - The keystore's controller.
    * @param {string} options.referenceId - The keystore's reference ID.
-   * @param {https.Agent} [options.httpsAgent=undefined] - An optional
+   * @param {object} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
    * @returns {Promise<object>} Resolves to the configuration for the keystore.

--- a/KmsClient.js
+++ b/KmsClient.js
@@ -10,13 +10,21 @@ import {signCapabilityInvocation} from 'http-signature-zcap-invoke';
 const SECURITY_CONTEXT_V2_URL = 'https://w3id.org/security/v2';
 const DEFAULT_HEADERS = {Accept: 'application/ld+json, application/json'};
 
+/**
+ * A node https module.
+ *
+ * @typedef {object} https
+ * @see https://nodejs.org/docs/latest-v11.x/api/https.html
+ */
+
 export class KmsClient {
   /**
    * Creates a new KmsClient.
    *
-   * @param {Object} options - The options to use.
-   * @param {string} [keystore=undefined] the ID of the keystore that must be a
-   *   URL that refers to the keystore's root storage location; if not given,
+   * @param {object} options - The options to use.
+   * @param {string} [options.keystore=undefined] - The ID of the keystore
+   * that must be a URL that refers to the keystore's root storage
+   * location; if not given,
    *   then a separate capability must be given to each method called on the
    *   client instance.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
@@ -32,15 +40,15 @@ export class KmsClient {
   /**
    * Generates a new cryptographic key in the keystore.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.kmsModule - The KMS module to use.
    * @param {string} options.type - The key type (e.g. 'AesKeyWrappingKey2019').
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @returns {Promise<Object>} The key description for the key.
+   * @returns {Promise<object>} The key description for the key.
    */
   async generateKey({kmsModule, type, capability, invocationSigner}) {
     _assert(kmsModule, 'kmsModule', 'string');
@@ -88,14 +96,14 @@ export class KmsClient {
   /**
    * Gets the key description for the given key ID.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} [options.keyId] - The ID of the key.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @returns {Promise<Object>} The key description.
+   * @returns {Promise<object>} The key description.
    */
   async getKeyDescription({keyId, capability, invocationSigner}) {
     _assert(invocationSigner, 'invocationSigner', 'object');
@@ -134,13 +142,13 @@ export class KmsClient {
   /**
    * Wraps a cryptographic key using a key encryption key (KEK).
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.kekId - The ID of the wrapping key to use.
    * @param {Uint8Array} options.unwrappedKey - The unwrapped key material as
    *   a Uint8Array.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
    * @returns {Promise<string>} The base64url-encoded wrapped key bytes.
@@ -189,13 +197,13 @@ export class KmsClient {
   /**
    * Unwraps a cryptographic key using a key encryption key (KEK).
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.kekId - The ID of the unwrapping key to use.
    * @param {string} options.wrappedKey - The wrapped key material as a
    *   base64url-encoded string.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
    * @returns {Promise<Uint8Array|null>} Resolves to the unwrapped key material
@@ -251,12 +259,12 @@ export class KmsClient {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.keyId - The ID of the signing key to use.
    * @param {Uint8Array} options.data - The data to sign as a Uint8Array.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
    * @returns {Promise<string>} The base64url-encoded signature.
@@ -308,14 +316,14 @@ export class KmsClient {
    * hashing the data first may present interoperability issues so choose
    * wisely.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.keyId - The ID of the signing key to use.
    * @param {Uint8Array} options.data - The data to verify as a Uint8Array.
    * @param {string} options.signature - The base64url-encoded signature to
    *   verify.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
    * @returns {Promise<boolean>} `true` if verified, `false` if not.
@@ -369,14 +377,14 @@ export class KmsClient {
    * a shared key itself, but rather input into a key derivation function (KDF)
    * to produce a shared key.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.keyId - The ID of the key agreement key to use.
-   * @param {Object} options.publicKey - The public key to compute the shared
+   * @param {object} options.publicKey - The public key to compute the shared
    *   secret against; the public key type must match the key agreement key's
    *   type.
    * @param {string} [options.capability=undefined] - The OCAP-LD authorization
    *   capability to use to authorize the invocation of this operation.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
    * @returns {Promise<Uint8Array>} The shared secret bytes.
@@ -426,12 +434,12 @@ export class KmsClient {
    * Stores a delegated authorization capability, enabling it to be invoked by
    * its designated invoker.
    *
-   * @param {Object} options - The options to use.
-   * @param {Object} options.capabilityToEnable the capability to enable.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options - The options to use.
+   * @param {object} options.capabilityToEnable - The capability to enable.
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Object>} resolves once the operation completes.
+   * @returns {Promise<object>} Resolves once the operation completes.
    */
   async enableCapability({capabilityToEnable, invocationSigner}) {
     _assert(capabilityToEnable, 'capabilityToEnable', 'object');
@@ -464,12 +472,12 @@ export class KmsClient {
    * Removes a previously stored delegated authorization capability, preventing
    * it from being invoked by its designated invoker.
    *
-   * @param {Object} options - The options to use.
-   * @param {Object} options.id the ID of the capability to revoke.
-   * @param {Object} options.invocationSigner - An API with an
+   * @param {object} options - The options to use.
+   * @param {object} options.id - The ID of the capability to revoke.
+   * @param {object} options.invocationSigner - An API with an
    *   `id` property and a `sign` function for signing a capability invocation.
    *
-   * @return {Promise<Boolean>} resolves to `true` if the document was deleted
+   * @returns {Promise<boolean>} Resolves to `true` if the document was deleted
    *   and `false` if it did not exist.
    */
   async disableCapability({id, invocationSigner}) {
@@ -502,13 +510,13 @@ export class KmsClient {
   /**
    * Creates a new keystore using the given configuration.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} options.url - The url to post the configuration to.
    * @param {string} options.config - The keystore's configuration.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
-   * @return {Promise<Object>} resolves to the configuration for the newly
+   * @returns {Promise<object>} Resolves to the configuration for the newly
    *   created keystore.
    */
   static async createKeystore({url = '/kms/keystores', config, httpsAgent}) {
@@ -523,12 +531,12 @@ export class KmsClient {
   /**
    * Gets the configuration for a keystore by its ID.
    *
-   * @param {Object} options - The options to use.
-   * @param {string} options.id the keystore's ID.
+   * @param {object} options - The options to use.
+   * @param {string} options.id - The keystore's ID.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
-   * @return {Promise<Object>} resolves to the configuration for the keystore.
+   * @returns {Promise<object>} Resolves to the configuration for the keystore.
    */
   static async getKeystore({id, httpsAgent}) {
     _assert(id, 'id', 'string');
@@ -540,14 +548,14 @@ export class KmsClient {
   /**
    * Finds the configuration for a keystore by its controller and reference ID.
    *
-   * @param {Object} options - The options to use.
+   * @param {object} options - The options to use.
    * @param {string} [options.url] - The url to query.
-   * @param {string} options.controller the keystore's controller.
-   * @param {string} options.referenceId the keystore's reference ID.
+   * @param {string} options.controller - The keystore's controller.
+   * @param {string} options.referenceId - The keystore's reference ID.
    * @param {https.Agent} [options.httpsAgent=undefined] - An optional
    *   node.js `https.Agent` instance to use when making requests.
    *
-   * @return {Promise<Object>} resolves to the configuration for the keystore.
+   * @returns {Promise<object>} Resolves to the configuration for the keystore.
    */
   static async findKeystore(
     {url = '/kms/keystores', controller, referenceId, httpsAgent}) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
     "eslint-plugin-jsdoc": "^15.8.1",
+    "jsdoc": "3.6.2",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "crypto-ld": "^3.5.1",
     "eslint": "^5.16.0",
     "eslint-config-digitalbazaar": "^2.0.0",
+    "eslint-plugin-jsdoc": "^15.8.1",
     "karma": "^4.0.1",
     "karma-babel-preprocessor": "^8.0.0",
     "karma-chai": "^0.1.0",


### PR DESCRIPTION
this removes all lint errors in all files while also enabling jsdoc lint rules.
I would use that project that auto-generates the markdown files form jsdoc, but it's not working for some reason.